### PR TITLE
fix: relay error messages for better visibility

### DIFF
--- a/src/AssetHandler.js
+++ b/src/AssetHandler.js
@@ -180,6 +180,13 @@ class AssetHandler {
     try {
       stream = await requestStream(options)
     } catch (err) {
+      const message = 'Failed to create asset stream'
+      if (typeof err.message === 'string') {
+        // try to re-assign the error message so the stack trace is more visible
+        err.message = `${message}: ${err.message}`
+        throw err
+      }
+
       throw new Error('Failed create asset stream', {cause: err})
     }
 
@@ -194,7 +201,14 @@ class AssetHandler {
 
         throw new Error(errMsg)
       } catch (err) {
-        throw new Error('Failed to parse error response from asset stream', {cause: err})
+        const message = 'Failed to parse error response from asset stream'
+        if (typeof err.message === 'string') {
+          // try to re-assign the error message so the stack trace is more visible
+          err.message = `${message}: ${err.message}`
+          throw err
+        }
+
+        throw new Error(message, {cause: err})
       }
     }
 
@@ -211,7 +225,14 @@ class AssetHandler {
       md5 = res.md5
       size = res.size
     } catch (err) {
-      throw new Error('Failed to write asset stream to filesystem', {cause: err})
+      const message = 'Failed to write asset stream to filesystem'
+
+      if (typeof err.message === 'string') {
+        err.message = `${message}: ${err.message}`
+        throw err
+      }
+
+      throw new Error(message, {cause: err})
     }
 
     // Verify it against our downloaded stream to make sure we have the same copy


### PR DESCRIPTION
We had a few customers with failing exports with error messages that came from the AssetHandler. These error messages did not display the original message which in many cases is very helpful to the developer running the export.

This fix just surfaces the original error a little better. Ideally we shouldn't have to do this but the way these errors are reported to the console omits important information. For example the following error was swallowed when this could help give clues to devs to why their export is failing.
 
![CleanShot 2024-04-18 at 10 42 24@2x](https://github.com/sanity-io/export/assets/10551026/d53a1676-c3e1-41a6-b40c-7287363ec36d)
