### PR TITLE
chore: update release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,28 +4,36 @@ on:
     branches:
       - main
       - alpha
+
 jobs:
   release:
     name: Release
     environment:
       name: npm-production
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      NPM_CONFIG_PROVENANCE: true
     runs-on: ubuntu-latest
     permissions:
-      contents: write # to be able to publish a GitHub release
-      issues: write # to be able to comment on released issues
-      pull-requests: write # to be able to comment on released pull requests
+      contents: read # for checkout
       id-token: write # to enable use of OIDC for npm provenance
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Create app token
+        uses: actions/create-github-app-token@v1
+        id: app-token
         with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Need all history to analyze commits since last release
           fetch-depth: 0
+          # Uses generated token to allow pushing commits back
+          token: ${{ steps.app-token.outputs.token }}
+          # Make sure GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: lts/*
 
@@ -37,6 +45,7 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: npx semantic-release


### PR DESCRIPTION
This PR updates the `release.yml` workflow to use our ecospark GitHub app for authentication to bypass the new `main` ruleset (which is currently disabled)

Note this PR should not be merged until the `ECOSPARK_APP_ID` and `ECOSPARK_APP_PRIVATE_KEY` have been added to the [`npm-production`](https://github.com/sanity-io/export/settings/environments/2775554117/edit) environment.

After that the, the [`main`](https://github.com/sanity-io/export/settings/rules/756655) ruleset can be set to active.

Shoutout to @stipsan for the help here.