### PR TITLE
fix(export): request does not throw error on failure

### DIFF
--- a/src/requestStream.js
+++ b/src/requestStream.js
@@ -42,6 +42,12 @@ module.exports = async (options) => {
           )
         })
       }
+      
+      if (response.statusCode !== 200) {
+        throw new Error(
+          `Export: Failed to fetch ${options.url}: HTTP ${response.statusCode} ${response.statusMessage}`,
+        )
+      }
 
       return response
     } catch (err) {


### PR DESCRIPTION
Fixes for sanity dataset export immediately exited when an error of status code 500/502 happen when exporting 40K+ assets. The failing request URL are valid and accessible with browser but it randomly throw an error and fail the cli command which causes user to rerun the entire export process.

The error message output in terminal:
`Error: Referenced asset URL "https://cdn.sanity.io/images/[app_id]/[dataset]/[resource_id]-360x308.jpg" returned HTTP 500:
An internal server error occured
    at AssetHandler.downloadAsset (~/repo/node_modules/@sanity/export/src/AssetHandler.js:156:19)`

I have found the issue which is caused by the request (get-it library) that has statusCode of 500 or 502 response but it does not throw an error and therefore the retry was not triggered and it ends up throwing error in src/AssetHandler.js script at line 198 `if (stream.statusCode !== 200) {` and ending the script

Attaching the response object incase anyone needs it:

> IncomingMessage {
  _readableState: ReadableState {
    objectMode: false,
    highWaterMark: 16384,
    buffer: BufferList { head: [Object], tail: [Object], length: 1 },
    length: 95,
    pipes: [],
    flowing: null,
    ended: true,
    endEmitted: false,
    reading: false,
    constructed: true,
    sync: true,
    needReadable: false,
    emittedReadable: false,
    readableListening: false,
    resumeScheduled: false,
    errorEmitted: false,
    emitClose: true,
    autoDestroy: true,
    destroyed: false,
    errored: null,
    closed: false,
    closeEmitted: false,
    defaultEncoding: 'utf8',
    awaitDrainWriters: null,
    multiAwaitDrain: false,
    readingMore: true,
    dataEmitted: false,
    decoder: null,
    encoding: null,
    [Symbol(kPaused)]: null
  },
  _events: [Object: null prototype] { end: [Function: responseOnEnd] },
  _eventsCount: 1,
  _maxListeners: undefined,
  socket: <ref *1> TLSSocket {
    _tlsOptions: {
      allowHalfOpen: undefined,
      pipe: false,
      secureContext: [SecureContext],
      isServer: false,
      requestCert: true,
      rejectUnauthorized: true,
      session: undefined,
      ALPNProtocols: undefined,
      requestOCSP: undefined,
      enableTrace: undefined,
      pskCallback: undefined,
      highWaterMark: undefined,
      onread: undefined,
      signal: undefined
    },
    _secureEstablished: true,
    _securePending: false,
    _newSessionPending: false,
    _controlReleased: true,
    secureConnecting: false,
    _SNICallback: null,
    servername: 'cdn.sanity.io',
    alpnProtocol: false,
    authorized: true,
    authorizationError: null,
    encrypted: true,
    _events: [Object: null prototype] {
      close: [Array],
      end: [Function: onReadableStreamEnd],
      newListener: [Function: keylogNewListener],
      secure: [Function: onConnectSecure],
      session: [Function (anonymous)],
      free: [Function: onFree],
      timeout: [Array],
      agentRemove: [Function: onRemove],
      error: [Function: socketErrorListener]
    },
    _eventsCount: 9,
    connecting: false,
    _hadError: false,
    _parent: null,
    _host: 'cdn.sanity.io',
    _closeAfterHandlingError: false,
    _readableState: ReadableState {
      objectMode: false,
      highWaterMark: 16384,
      buffer: BufferList { head: null, tail: null, length: 0 },
      length: 0,
      pipes: [],
      flowing: true,
      ended: false,
      endEmitted: false,
      reading: true,
      constructed: true,
      sync: false,
      needReadable: true,
      emittedReadable: false,
      readableListening: false,
      resumeScheduled: false,
      errorEmitted: false,
      emitClose: false,
      autoDestroy: true,
      destroyed: false,
      errored: null,
      closed: false,
      closeEmitted: false,
      defaultEncoding: 'utf8',
      awaitDrainWriters: null,
      multiAwaitDrain: false,
      readingMore: false,
      dataEmitted: true,
      decoder: null,
      encoding: null,
      [Symbol(kPaused)]: false
    },
    _maxListeners: undefined,
    _writableState: WritableState {
      objectMode: false,
      highWaterMark: 16384,
      finalCalled: false,
      needDrain: false,
      ending: false,
      ended: false,
      finished: false,
      destroyed: false,
      decodeStrings: false,
      defaultEncoding: 'utf8',
      length: 0,
      writing: false,
      corked: 0,
      sync: false,
      bufferProcessing: false,
      onwrite: [Function: bound onwrite],
      writecb: null,
      writelen: 0,
      afterWriteTickInfo: null,
      buffered: [],
      bufferedIndex: 0,
      allBuffers: true,
      allNoop: true,
      pendingcb: 0,
      constructed: true,
      prefinished: false,
      errorEmitted: false,
      emitClose: false,
      autoDestroy: true,
      errored: null,
      closed: false,
      closeEmitted: false,
      [Symbol(kOnFinished)]: []
    },
    allowHalfOpen: false,
    _sockname: null,
    _pendingData: null,
    _pendingEncoding: '',
    server: undefined,
    _server: null,
    ssl: TLSWrap {
      _parent: [TCP],
      _parentWrap: undefined,
      _secureContext: [SecureContext],
      reading: true,
      onkeylog: [Function: onkeylog],
      onhandshakestart: {},
      onhandshakedone: [Function (anonymous)],
      onocspresponse: [Function: onocspresponse],
      onnewsession: [Function: onnewsessionclient],
      onerror: [Function: onerror],
      [Symbol(owner_symbol)]: [Circular *1],
      [Symbol(resource_symbol)]: [ReusedHandle]
    },
    _requestCert: true,
    _rejectUnauthorized: true,
    parser: null,
    _httpMessage: ClientRequest {
      _events: [Object: null prototype],
      _eventsCount: 4,
      _maxListeners: undefined,
      outputData: [],
      outputSize: 0,
      writable: true,
      destroyed: false,
      _last: true,
      chunkedEncoding: false,
      shouldKeepAlive: true,
      maxRequestsOnConnectionReached: false,
      _defaultKeepAlive: true,
      useChunkedEncodingByDefault: false,
      sendDate: false,
      _removedConnection: false,
      _removedContLen: false,
      _removedTE: false,
      strictContentLength: false,
      _contentLength: 0,
      _hasBody: true,
      _trailer: '',
      finished: true,
      _headerSent: true,
      _closed: false,
      socket: [Circular *1],
      _header: 'GET /images/[app_id]/[dataset]/[resource_id]-376x154.jpg?dlRaw=true HTTP/1.1\r\n' +
        'user-agent: @sanity/export@3.19.2\r\n' +
        'authorization: Bearer [bearer_token]\r\n' +
        'accept-encoding: br, gzip, deflate\r\n' +
        'Host: cdn.sanity.io\r\n' +
        'Connection: keep-alive\r\n' +
        '\r\n',
      _keepAliveTimeout: 0,
      _onPendingData: [Function: nop],
      agent: [Agent],
      socketPath: undefined,
      method: 'GET',
      maxHeaderSize: undefined,
      insecureHTTPParser: undefined,
      joinDuplicateHeaders: undefined,
      path: '/images/[app_id]/[dataset]/[resource_id]-376x154.jpg?dlRaw=true',
      _ended: false,
      res: [Circular *2],
      aborted: false,
      timeoutCb: [Function: emitRequestTimeout],
      upgradeOrConnect: false,
      parser: null,
      maxHeadersCount: null,
      reusedSocket: true,
      host: 'cdn.sanity.io',
      protocol: 'https:',
      timeoutTimer: null,
      [Symbol(kCapture)]: false,
      [Symbol(kBytesWritten)]: 0,
      [Symbol(kNeedDrain)]: false,
      [Symbol(corked)]: 0,
      [Symbol(kOutHeaders)]: [Object: null prototype],
      [Symbol(errored)]: null,
      [Symbol(kHighWaterMark)]: 16384,
      [Symbol(kRejectNonStandardBodyWrites)]: false,
      [Symbol(kUniqueHeaders)]: null
    },
    timeout: 180000,
    [Symbol(res)]: TLSWrap {
      _parent: [TCP],
      _parentWrap: undefined,
      _secureContext: [SecureContext],
      reading: true,
      onkeylog: [Function: onkeylog],
      onhandshakestart: {},
      onhandshakedone: [Function (anonymous)],
      onocspresponse: [Function: onocspresponse],
      onnewsession: [Function: onnewsessionclient],
      onerror: [Function: onerror],
      [Symbol(owner_symbol)]: [Circular *1],
      [Symbol(resource_symbol)]: [ReusedHandle]
    },
    [Symbol(verified)]: true,
    [Symbol(pendingSession)]: null,
    [Symbol(async_id_symbol)]: 3386309,
    [Symbol(kHandle)]: TLSWrap {
      _parent: [TCP],
      _parentWrap: undefined,
      _secureContext: [SecureContext],
      reading: true,
      onkeylog: [Function: onkeylog],
      onhandshakestart: {},
      onhandshakedone: [Function (anonymous)],
      onocspresponse: [Function: onocspresponse],
      onnewsession: [Function: onnewsessionclient],
      onerror: [Function: onerror],
      [Symbol(owner_symbol)]: [Circular *1],
      [Symbol(resource_symbol)]: [ReusedHandle]
    },
    [Symbol(lastWriteQueueSize)]: 0,
    [Symbol(timeout)]: Timeout {
      _idleTimeout: 180000,
      _idlePrev: [TimersList],
      _idleNext: [Timeout],
      _idleStart: 1334887,
      _onTimeout: [Function: bound ],
      _timerArgs: undefined,
      _repeat: null,
      _destroyed: false,
      [Symbol(refed)]: false,
      [Symbol(kHasPrimitive)]: false,
      [Symbol(asyncId)]: 3386313,
      [Symbol(triggerId)]: 3386310
    },
    [Symbol(kBuffer)]: null,
    [Symbol(kBufferCb)]: null,
    [Symbol(kBufferGen)]: null,
    [Symbol(kCapture)]: false,
    [Symbol(kSetNoDelay)]: false,
    [Symbol(kSetKeepAlive)]: true,
    [Symbol(kSetKeepAliveInitialDelay)]: 1,
    [Symbol(kBytesRead)]: 0,
    [Symbol(kBytesWritten)]: 0,
    [Symbol(connect-options)]: {
      rejectUnauthorized: true,
      ciphers: 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA256:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA',
      checkServerIdentity: [Function: checkServerIdentity],
      minDHSize: 1024,
      protocol: 'https:',
      slashes: true,
      auth: null,
      host: 'cdn.sanity.io',
      port: 443,
      hostname: 'cdn.sanity.io',
      hash: null,
      search: null,
      query: null,
      pathname: '/files/[app_id]/[dataset]/[html_id].html',
      path: null,
      href: 'https://cdn.sanity.io/files/[app_id]/[dataset]/[html_id].html',
      method: 'GET',
      headers: [Object],
      maxRedirects: 0,
      agent: [Agent],
      _defaultAgent: [Agent],
      keepAlive: true,
      keepAliveMsecs: 1000,
      maxFreeSockets: 256,
      noDelay: true,
      servername: 'cdn.sanity.io',
      _agentKey: 'cdn.sanity.io:443:::::::::::::::::::::',
      encoding: null,
      keepAliveInitialDelay: 1000
    }
  },
  httpVersionMajor: 1,
  httpVersionMinor: 1,
  httpVersion: '1.1',
  complete: true,
  rawHeaders: [
    'Content-Type',
    'application/json; charset=utf-8',
    'Content-Length',
    '95',
    'x-b3-traceid',
    '7eb05640e56320cb5800de44fddfffe0',
    'x-b3-parentspanid',
    'b236ddbdfb684efd',
    'x-b3-spanid',
    'f9f7c99809ac1ea4',
    'x-b3-sampled',
    '0',
    'Vary',
    'origin, authorization',
    'cache-control',
    'public, max-age=1, s-maxage=1',
    'pragma',
    'no-cache',
    'x-sanity-asset-storage',
    'gcs-default',
    'Date',
    'Tue, 14 May 2024 11:47:30 GMT',
    'strict-transport-security',
    'max-age=63072000; includeSubDomains; preload',
    'xkey',
    'project-[app_id]-[dataset]',
    'x-varnish-beresp-ttl',
    '1.000',
    'grace',
    '0.000',
    'X-Varnish-Age',
    '0',
    'Via',
    '1.1 google',
    'Alt-Svc',
    'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000'
  ],
  rawTrailers: [],
  joinDuplicateHeaders: undefined,
  aborted: false,
  upgrade: false,
  url: '',
  method: null,
  statusCode: 500,
  statusMessage: 'Internal Server Error',
  client: <ref *1> TLSSocket {
    _tlsOptions: {
      allowHalfOpen: undefined,
      pipe: false,
      secureContext: [SecureContext],
      isServer: false,
      requestCert: true,
      rejectUnauthorized: true,
      session: undefined,
      ALPNProtocols: undefined,
      requestOCSP: undefined,
      enableTrace: undefined,
      pskCallback: undefined,
      highWaterMark: undefined,
      onread: undefined,
      signal: undefined
    },
    _secureEstablished: true,
    _securePending: false,
    _newSessionPending: false,
    _controlReleased: true,
    secureConnecting: false,
    _SNICallback: null,
    servername: 'cdn.sanity.io',
    alpnProtocol: false,
    authorized: true,
    authorizationError: null,
    encrypted: true,
    _events: [Object: null prototype] {
      close: [Array],
      end: [Function: onReadableStreamEnd],
      newListener: [Function: keylogNewListener],
      secure: [Function: onConnectSecure],
      session: [Function (anonymous)],
      free: [Function: onFree],
      timeout: [Array],
      agentRemove: [Function: onRemove],
      error: [Function: socketErrorListener]
    },
    _eventsCount: 9,
    connecting: false,
    _hadError: false,
    _parent: null,
    _host: 'cdn.sanity.io',
    _closeAfterHandlingError: false,
    _readableState: ReadableState {
      objectMode: false,
      highWaterMark: 16384,
      buffer: BufferList { head: null, tail: null, length: 0 },
      length: 0,
      pipes: [],
      flowing: true,
      ended: false,
      endEmitted: false,
      reading: true,
      constructed: true,
      sync: false,
      needReadable: true,
      emittedReadable: false,
      readableListening: false,
      resumeScheduled: false,
      errorEmitted: false,
      emitClose: false,
      autoDestroy: true,
      destroyed: false,
      errored: null,
      closed: false,
      closeEmitted: false,
      defaultEncoding: 'utf8',
      awaitDrainWriters: null,
      multiAwaitDrain: false,
      readingMore: false,
      dataEmitted: true,
      decoder: null,
      encoding: null,
      [Symbol(kPaused)]: false
    },
    _maxListeners: undefined,
    _writableState: WritableState {
      objectMode: false,
      highWaterMark: 16384,
      finalCalled: false,
      needDrain: false,
      ending: false,
      ended: false,
      finished: false,
      destroyed: false,
      decodeStrings: false,
      defaultEncoding: 'utf8',
      length: 0,
      writing: false,
      corked: 0,
      sync: false,
      bufferProcessing: false,
      onwrite: [Function: bound onwrite],
      writecb: null,
      writelen: 0,
      afterWriteTickInfo: null,
      buffered: [],
      bufferedIndex: 0,
      allBuffers: true,
      allNoop: true,
      pendingcb: 0,
      constructed: true,
      prefinished: false,
      errorEmitted: false,
      emitClose: false,
      autoDestroy: true,
      errored: null,
      closed: false,
      closeEmitted: false,
      [Symbol(kOnFinished)]: []
    },
    allowHalfOpen: false,
    _sockname: null,
    _pendingData: null,
    _pendingEncoding: '',
    server: undefined,
    _server: null,
    ssl: TLSWrap {
      _parent: [TCP],
      _parentWrap: undefined,
      _secureContext: [SecureContext],
      reading: true,
      onkeylog: [Function: onkeylog],
      onhandshakestart: {},
      onhandshakedone: [Function (anonymous)],
      onocspresponse: [Function: onocspresponse],
      onnewsession: [Function: onnewsessionclient],
      onerror: [Function: onerror],
      [Symbol(owner_symbol)]: [Circular *1],
      [Symbol(resource_symbol)]: [ReusedHandle]
    },
    _requestCert: true,
    _rejectUnauthorized: true,
    parser: null,
    _httpMessage: ClientRequest {
      _events: [Object: null prototype],
      _eventsCount: 4,
      _maxListeners: undefined,
      outputData: [],
      outputSize: 0,
      writable: true,
      destroyed: false,
      _last: true,
      chunkedEncoding: false,
      shouldKeepAlive: true,
      maxRequestsOnConnectionReached: false,
      _defaultKeepAlive: true,
      useChunkedEncodingByDefault: false,
      sendDate: false,
      _removedConnection: false,
      _removedContLen: false,
      _removedTE: false,
      strictContentLength: false,
      _contentLength: 0,
      _hasBody: true,
      _trailer: '',
      finished: true,
      _headerSent: true,
      _closed: false,
      socket: [Circular *1],
      _header: 'GET /images/[app_id]/[dataset]/[resource_id]-376x154.jpg?dlRaw=true HTTP/1.1\r\n' +
        'user-agent: @sanity/export@3.19.2\r\n' +
        'authorization: Bearer [bearer_token]\r\n' +
        'accept-encoding: br, gzip, deflate\r\n' +
        'Host: cdn.sanity.io\r\n' +
        'Connection: keep-alive\r\n' +
        '\r\n',
      _keepAliveTimeout: 0,
      _onPendingData: [Function: nop],
      agent: [Agent],
      socketPath: undefined,
      method: 'GET',
      maxHeaderSize: undefined,
      insecureHTTPParser: undefined,
      joinDuplicateHeaders: undefined,
      path: '/images/[app_id]/[dataset]/[resource_id]-376x154.jpg?dlRaw=true',
      _ended: false,
      res: [Circular *2],
      aborted: false,
      timeoutCb: [Function: emitRequestTimeout],
      upgradeOrConnect: false,
      parser: null,
      maxHeadersCount: null,
      reusedSocket: true,
      host: 'cdn.sanity.io',
      protocol: 'https:',
      timeoutTimer: null,
      [Symbol(kCapture)]: false,
      [Symbol(kBytesWritten)]: 0,
      [Symbol(kNeedDrain)]: false,
      [Symbol(corked)]: 0,
      [Symbol(kOutHeaders)]: [Object: null prototype],
      [Symbol(errored)]: null,
      [Symbol(kHighWaterMark)]: 16384,
      [Symbol(kRejectNonStandardBodyWrites)]: false,
      [Symbol(kUniqueHeaders)]: null
    },
    timeout: 180000,
    [Symbol(res)]: TLSWrap {
      _parent: [TCP],
      _parentWrap: undefined,
      _secureContext: [SecureContext],
      reading: true,
      onkeylog: [Function: onkeylog],
      onhandshakestart: {},
      onhandshakedone: [Function (anonymous)],
      onocspresponse: [Function: onocspresponse],
      onnewsession: [Function: onnewsessionclient],
      onerror: [Function: onerror],
      [Symbol(owner_symbol)]: [Circular *1],
      [Symbol(resource_symbol)]: [ReusedHandle]
    },
    [Symbol(verified)]: true,
    [Symbol(pendingSession)]: null,
    [Symbol(async_id_symbol)]: 3386309,
    [Symbol(kHandle)]: TLSWrap {
      _parent: [TCP],
      _parentWrap: undefined,
      _secureContext: [SecureContext],
      reading: true,
      onkeylog: [Function: onkeylog],
      onhandshakestart: {},
      onhandshakedone: [Function (anonymous)],
      onocspresponse: [Function: onocspresponse],
      onnewsession: [Function: onnewsessionclient],
      onerror: [Function: onerror],
      [Symbol(owner_symbol)]: [Circular *1],
      [Symbol(resource_symbol)]: [ReusedHandle]
    },
    [Symbol(lastWriteQueueSize)]: 0,
    [Symbol(timeout)]: Timeout {
      _idleTimeout: 180000,
      _idlePrev: [TimersList],
      _idleNext: [Timeout],
      _idleStart: 1334887,
      _onTimeout: [Function: bound ],
      _timerArgs: undefined,
      _repeat: null,
      _destroyed: false,
      [Symbol(refed)]: false,
      [Symbol(kHasPrimitive)]: false,
      [Symbol(asyncId)]: 3386313,
      [Symbol(triggerId)]: 3386310
    },
    [Symbol(kBuffer)]: null,
    [Symbol(kBufferCb)]: null,
    [Symbol(kBufferGen)]: null,
    [Symbol(kCapture)]: false,
    [Symbol(kSetNoDelay)]: false,
    [Symbol(kSetKeepAlive)]: true,
    [Symbol(kSetKeepAliveInitialDelay)]: 1,
    [Symbol(kBytesRead)]: 0,
    [Symbol(kBytesWritten)]: 0,
    [Symbol(connect-options)]: {
      rejectUnauthorized: true,
      ciphers: 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA256:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA',
      checkServerIdentity: [Function: checkServerIdentity],
      minDHSize: 1024,
      protocol: 'https:',
      slashes: true,
      auth: null,
      host: 'cdn.sanity.io',
      port: 443,
      hostname: 'cdn.sanity.io',
      hash: null,
      search: null,
      query: null,
      pathname: '/files/[app_id]/[dataset]/[html_id].html',
      path: null,
      href: 'https://cdn.sanity.io/files/[app_id]/[dataset]/[html_id].html',
      method: 'GET',
      headers: [Object],
      maxRedirects: 0,
      agent: [Agent],
      _defaultAgent: [Agent],
      keepAlive: true,
      keepAliveMsecs: 1000,
      maxFreeSockets: 256,
      noDelay: true,
      servername: 'cdn.sanity.io',
      _agentKey: 'cdn.sanity.io:443:::::::::::::::::::::',
      encoding: null,
      keepAliveInitialDelay: 1000
    }
  },
  _consuming: false,
  _dumped: false,
  req: <ref *3> ClientRequest {
    _events: [Object: null prototype] {
      socket: [Function: assign],
      error: [Array],
      timeout: [Function],
      finish: [Function: requestOnFinish]
    },
    _eventsCount: 4,
    _maxListeners: undefined,
    outputData: [],
    outputSize: 0,
    writable: true,
    destroyed: false,
    _last: true,
    chunkedEncoding: false,
    shouldKeepAlive: true,
    maxRequestsOnConnectionReached: false,
    _defaultKeepAlive: true,
    useChunkedEncodingByDefault: false,
    sendDate: false,
    _removedConnection: false,
    _removedContLen: false,
    _removedTE: false,
    strictContentLength: false,
    _contentLength: 0,
    _hasBody: true,
    _trailer: '',
    finished: true,
    _headerSent: true,
    _closed: false,
    socket: <ref *1> TLSSocket {
      _tlsOptions: [Object],
      _secureEstablished: true,
      _securePending: false,
      _newSessionPending: false,
      _controlReleased: true,
      secureConnecting: false,
      _SNICallback: null,
      servername: 'cdn.sanity.io',
      alpnProtocol: false,
      authorized: true,
      authorizationError: null,
      encrypted: true,
      _events: [Object: null prototype],
      _eventsCount: 9,
      connecting: false,
      _hadError: false,
      _parent: null,
      _host: 'cdn.sanity.io',
      _closeAfterHandlingError: false,
      _readableState: [ReadableState],
      _maxListeners: undefined,
      _writableState: [WritableState],
      allowHalfOpen: false,
      _sockname: null,
      _pendingData: null,
      _pendingEncoding: '',
      server: undefined,
      _server: null,
      ssl: [TLSWrap],
      _requestCert: true,
      _rejectUnauthorized: true,
      parser: null,
      _httpMessage: [Circular *3],
      timeout: 180000,
      [Symbol(res)]: [TLSWrap],
      [Symbol(verified)]: true,
      [Symbol(pendingSession)]: null,
      [Symbol(async_id_symbol)]: 3386309,
      [Symbol(kHandle)]: [TLSWrap],
      [Symbol(lastWriteQueueSize)]: 0,
      [Symbol(timeout)]: Timeout {
        _idleTimeout: 180000,
        _idlePrev: [TimersList],
        _idleNext: [Timeout],
        _idleStart: 1334887,
        _onTimeout: [Function: bound ],
        _timerArgs: undefined,
        _repeat: null,
        _destroyed: false,
        [Symbol(refed)]: false,
        [Symbol(kHasPrimitive)]: false,
        [Symbol(asyncId)]: 3386313,
        [Symbol(triggerId)]: 3386310
      },
      [Symbol(kBuffer)]: null,
      [Symbol(kBufferCb)]: null,
      [Symbol(kBufferGen)]: null,
      [Symbol(kCapture)]: false,
      [Symbol(kSetNoDelay)]: false,
      [Symbol(kSetKeepAlive)]: true,
      [Symbol(kSetKeepAliveInitialDelay)]: 1,
      [Symbol(kBytesRead)]: 0,
      [Symbol(kBytesWritten)]: 0,
      [Symbol(connect-options)]: [Object]
    },
    _header: 'GET /images/[app_id]/[dataset]/[resource_id]-376x154.jpg?dlRaw=true HTTP/1.1\r\n' +
      'user-agent: @sanity/export@3.19.2\r\n' +
      'authorization: Bearer [bearer_token]\r\n' +
      'accept-encoding: br, gzip, deflate\r\n' +
      'Host: cdn.sanity.io\r\n' +
      'Connection: keep-alive\r\n' +
      '\r\n',
    _keepAliveTimeout: 0,
    _onPendingData: [Function: nop],
    agent: Agent {
      _events: [Object: null prototype],
      _eventsCount: 2,
      _maxListeners: undefined,
      defaultPort: 443,
      protocol: 'https:',
      options: [Object: null prototype],
      requests: [Object: null prototype] {},
      sockets: [Object: null prototype],
      freeSockets: [Object: null prototype] {},
      keepAliveMsecs: 1000,
      keepAlive: true,
      maxSockets: Infinity,
      maxFreeSockets: 256,
      scheduling: 'lifo',
      maxTotalSockets: Infinity,
      totalSocketCount: 8,
      maxCachedSessions: 100,
      _sessionCache: [Object],
      [Symbol(kCapture)]: false
    },
    socketPath: undefined,
    method: 'GET',
    maxHeaderSize: undefined,
    insecureHTTPParser: undefined,
    joinDuplicateHeaders: undefined,
    path: '/images/[app_id]/[dataset]/[resource_id]-376x154.jpg?dlRaw=true',
    _ended: false,
    res: [Circular *2],
    aborted: false,
    timeoutCb: [Function: emitRequestTimeout],
    upgradeOrConnect: false,
    parser: null,
    maxHeadersCount: null,
    reusedSocket: true,
    host: 'cdn.sanity.io',
    protocol: 'https:',
    timeoutTimer: null,
    [Symbol(kCapture)]: false,
    [Symbol(kBytesWritten)]: 0,
    [Symbol(kNeedDrain)]: false,
    [Symbol(corked)]: 0,
    [Symbol(kOutHeaders)]: [Object: null prototype] {
      'user-agent': [Array],
      authorization: [Array],
      'accept-encoding': [Array],
      host: [Array]
    },
    [Symbol(errored)]: null,
    [Symbol(kHighWaterMark)]: 16384,
    [Symbol(kRejectNonStandardBodyWrites)]: false,
    [Symbol(kUniqueHeaders)]: null
  },
  [Symbol(kCapture)]: false,
  [Symbol(kHeaders)]: {
    'content-type': 'application/json; charset=utf-8',
    'content-length': '95',
    'x-b3-traceid': '7eb05640e56320cb5800de44fddfffe0',
    'x-b3-parentspanid': 'b236ddbdfb684efd',
    'x-b3-spanid': 'f9f7c99809ac1ea4',
    'x-b3-sampled': '0',
    vary: 'origin, authorization',
    'cache-control': 'public, max-age=1, s-maxage=1',
    pragma: 'no-cache',
    'x-sanity-asset-storage': 'gcs-default',
    date: 'Tue, 14 May 2024 11:47:30 GMT',
    'strict-transport-security': 'max-age=63072000; includeSubDomains; preload',
    xkey: 'project-[app_id]-[dataset]',
    'x-varnish-beresp-ttl': '1.000',
    grace: '0.000',
    'x-varnish-age': '0',
    via: '1.1 google',
    'alt-svc': 'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000'
  },
  [Symbol(kHeadersCount)]: 36,
  [Symbol(kTrailers)]: null,
  [Symbol(kTrailersCount)]: 0
}