### PR TITLE
Clean up timeout handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@sanity/util": "3.37.2",
         "archiver": "^7.0.0",
         "debug": "^4.3.4",
-        "get-it": "^8.4.21",
+        "get-it": "^8.6.2",
         "lodash": "^4.17.21",
         "mississippi": "^4.0.0",
         "p-queue": "^2.3.0",
@@ -4867,18 +4867,13 @@
       }
     },
     "node_modules/get-it": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.4.27.tgz",
-      "integrity": "sha512-3ferjw17+sUrDws9Q5JOvC2ecaEjXQlBTarRNe7JLtKhzsnc7AILYzgn0TD0NZNuaeb7rEcGLX7tGHsDISJyAg==",
-      "workspaces": [
-        "test-next"
-      ],
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.6.2.tgz",
+      "integrity": "sha512-yZNwjgWGc1bmu+NGlb834A5SpfJAlVubOmyMjnwMnGdO4dpCshAFahFTC9Ct123FSf9cY1aSVPLJS2/BKaQ+GA==",
       "dependencies": {
         "decompress-response": "^7.0.0",
         "follow-redirects": "^1.15.6",
-        "into-stream": "^6.0.0",
         "is-retry-allowed": "^2.2.0",
-        "is-stream": "^2.0.1",
         "progress-stream": "^2.0.0",
         "tunnel-agent": "^0.6.0"
       },
@@ -5534,21 +5529,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/into-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
-      "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
-      "dependencies": {
-        "from2": "^2.3.0",
-        "p-is-promise": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-array-buffer": {
@@ -10631,6 +10611,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
       "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@sanity/util": "3.37.2",
     "archiver": "^7.0.0",
     "debug": "^4.3.4",
-    "get-it": "^8.4.21",
+    "get-it": "^8.6.2",
     "lodash": "^4.17.21",
     "mississippi": "^4.0.0",
     "p-queue": "^2.3.0",

--- a/src/constants.js
+++ b/src/constants.js
@@ -26,3 +26,10 @@ exports.ASSET_DOWNLOAD_CONCURRENCY = 8
  * @internal
  */
 exports.DOCUMENT_STREAM_DEBUG_INTERVAL = 10000
+
+/**
+ * How long to wait before timing out the read of a request due to inactivity.
+ * User overridable as `options.readTimeout`.
+ * @internal
+ */
+exports.REQUEST_READ_TIMEOUT = 3 * 60 * 1000 // 3 minutes

--- a/src/getDocumentsStream.js
+++ b/src/getDocumentsStream.js
@@ -11,5 +11,10 @@ module.exports = (options) => {
     ...(token ? {Authorization: `Bearer ${token}`} : {}),
   }
 
-  return requestStream({url, headers, maxRetries: options.maxRetries})
+  return requestStream({
+    url,
+    headers,
+    maxRetries: options.maxRetries,
+    readTimeout: options.readTimeout,
+  })
 }

--- a/src/requestStream.js
+++ b/src/requestStream.js
@@ -5,7 +5,6 @@ const {extractFirstError} = require('./util/extractFirstError')
 const {DOCUMENT_STREAM_MAX_RETRIES} = require('./constants')
 
 const request = getIt([keepAlive(), promise({onlyBody: true})])
-const socketsWithTimeout = new WeakSet()
 
 const CONNECTION_TIMEOUT = 15 * 1000 // 15 seconds
 const READ_TIMEOUT = 3 * 60 * 1000 // 3 minutes
@@ -23,27 +22,12 @@ module.exports = async (options) => {
   let error
   for (let i = 0; i < maxRetries; i++) {
     try {
-      const response = await request({
+      return await request({
         ...options,
         stream: true,
         maxRedirects: 0,
         timeout: {connect: CONNECTION_TIMEOUT, socket: READ_TIMEOUT},
       })
-
-      if (
-        response.connection &&
-        typeof response.connection.setTimeout === 'function' &&
-        !socketsWithTimeout.has(response.connection)
-      ) {
-        socketsWithTimeout.add(response.connection)
-        response.connection.setTimeout(READ_TIMEOUT, () => {
-          response.destroy(
-            new Error(`Export: Read timeout: No data received on socket for ${READ_TIMEOUT} ms`),
-          )
-        })
-      }
-
-      return response
     } catch (err) {
       error = extractFirstError(err)
 

--- a/src/validateOptions.js
+++ b/src/validateOptions.js
@@ -1,9 +1,13 @@
 const defaults = require('lodash/defaults')
-const {DOCUMENT_STREAM_MAX_RETRIES, ASSET_DOWNLOAD_MAX_RETRIES} = require('./constants')
+const {
+  DOCUMENT_STREAM_MAX_RETRIES,
+  ASSET_DOWNLOAD_MAX_RETRIES,
+  REQUEST_READ_TIMEOUT,
+} = require('./constants')
 
 const clientMethods = ['getUrl', 'config']
 const booleanFlags = ['assets', 'raw', 'compress', 'drafts']
-const numberFlags = ['maxAssetRetries', 'maxRetries', 'assetConcurrency']
+const numberFlags = ['maxAssetRetries', 'maxRetries', 'assetConcurrency', 'readTimeout']
 const exportDefaults = {
   compress: true,
   drafts: true,
@@ -11,6 +15,7 @@ const exportDefaults = {
   raw: false,
   maxRetries: DOCUMENT_STREAM_MAX_RETRIES,
   maxAssetRetries: ASSET_DOWNLOAD_MAX_RETRIES,
+  readTimeout: REQUEST_READ_TIMEOUT,
 }
 
 function validateOptions(opts) {

--- a/test/export.test.js
+++ b/test/export.test.js
@@ -442,9 +442,7 @@ describe('export', () => {
 
   test('throws error if unable to reach api', async () => {
     const options = await getOptions({port: 43210})
-    await expect(() => exportDataset(options)).rejects.toThrow(
-      /Failed to fetch.*connect ECONNREFUSED/,
-    )
+    await expect(() => exportDataset(options)).rejects.toThrow(/Failed to fetch/)
   }, 15000)
 
   test('throws error if api responds with 5xx error consistently', async () => {


### PR DESCRIPTION
- We don't need to do `response.connection.setTimeout` since this is provided by get-it
- Depend on the latest version of get-it which has improved timeout handling
- Add option for tweaking the read timeout.