### PR TITLE
fix: check for document _id-attribute to prevent throwing on error like document

### DIFF
--- a/src/rejectOnApiError.js
+++ b/src/rejectOnApiError.js
@@ -2,18 +2,26 @@ const miss = require('mississippi')
 
 module.exports = () =>
   miss.through.obj((doc, enc, callback) => {
-    if (doc.error && doc.statusCode) {
-      callback(
-        new Error(
-          ['Export', `HTTP ${doc.statusCode}`, doc.error, doc.message]
-            .filter((part) => typeof part === 'string')
-            .join(': '),
-        ),
-      )
+    // check if the document passed contains a document attribtue first, and return early.
+    if (doc._id) {
+      callback(null, doc)
       return
     }
 
-    if (!doc._id && doc.error) {
+    if (doc.error) {
+      // if we got a statusCode we can decorate the error with it
+      if (doc.statusCode) {
+        callback(
+          new Error(
+            ['Export', `HTTP ${doc.statusCode}`, doc.error, doc.message]
+              .filter((part) => typeof part === 'string')
+              .join(': '),
+          ),
+        )
+        return
+      }
+
+      // no statusCode, just serialize and return the error
       callback(new Error(doc.error.description || doc.error.message || JSON.stringify(doc)))
       return
     }

--- a/test/export.test.js
+++ b/test/export.test.js
@@ -482,4 +482,33 @@ describe('export', () => {
       'Export: HTTP 400: Bad Request: `@sanity/export` version too old, please update',
     )
   })
+
+  test('can export error like documents', async () => {
+    const port = 43217
+    const doc = {
+      _id: 'my-article',
+      _type: 'article',
+      error: 'my error',
+      statusCode: 500,
+    }
+
+    server = await getServer(port, (req, res) => {
+      res.writeHead(200, 'OK', {'Content-Type': 'application/x-ndjson'})
+      res.write(JSON.stringify(doc))
+      res.end()
+    })
+    const options = await getOptions({port, drafts: false})
+    const result = await exportDataset(options)
+    expect(result).toMatchObject({
+      assetCount: 0,
+      documentCount: 1,
+      outputPath: /out\.tar\.gz$/,
+    })
+
+    await assertContents(result.outputPath, {
+      documents: [doc],
+      images: {},
+      files: {},
+    })
+  })
 })


### PR DESCRIPTION
Context: https://sanity-io.slack.com/archives/C043ZRB9E4S/p1718142626345599

Unilever can't export their dataset since they got a document containing:

```
{
  "_id": "3T35tiU4dR8sP2qrXIe11r",
  "_rev": "JRFJVmIEnLYxUsWvoTu1qO",
  "_type": "clientError",
  "error": "\"Incorrect username or password.\"",
  "statusCode": "NotAuthorizedException"
}
```