### PR TITLE
Fix cursor export on ndjson inside a chunk

### DIFF
--- a/src/export.js
+++ b/src/export.js
@@ -120,8 +120,12 @@ async function exportDataset(opts) {
   }
 
   const inputStream = await getDocumentInputStream(options)
-  debug('Got HTTP %d', inputStream.statusCode)
-  debug('Response headers: %o', inputStream.headers)
+  if (inputStream.statusCode) {
+    debug('Got HTTP %d', inputStream.statusCode)
+  }
+  if (inputStream.headers) {
+    debug('Response headers: %o', inputStream.headers)
+  }
 
   let debugTimer = null
   function scheduleDebugTimer() {

--- a/src/filterSystemDocuments.js
+++ b/src/filterSystemDocuments.js
@@ -2,11 +2,16 @@ const miss = require('mississippi')
 const debug = require('./debug')
 
 const isSystemDocument = (doc) => doc && doc._id && doc._id.indexOf('_.') === 0
+const isCursor = (doc) => doc && !doc._id && doc.nextCursor !== undefined
 
 module.exports = () =>
   miss.through.obj((doc, enc, callback) => {
     if (isSystemDocument(doc)) {
       debug('%s is a system document, skipping', doc && doc._id)
+      return callback()
+    }
+    if (isCursor(doc)) {
+      debug('%o is a cursor, skipping', doc)
       return callback()
     }
 

--- a/src/getDocumentCursorStream.js
+++ b/src/getDocumentCursorStream.js
@@ -4,63 +4,63 @@ const pkg = require('../package.json')
 const debug = require('./debug')
 const requestStream = require('./requestStream')
 
+// same regex as split2 is using by default: https://github.com/mcollina/split2/blob/53432f54bd5bf422bd55d91d38f898b6c9496fc1/index.js#L86
+const splitRegex = /\r?\n/
+
 module.exports = async (options) => {
   let streamsInflight = 0
+  function decrementInflight(stream) {
+    streamsInflight--
+    if (streamsInflight === 0) {
+      stream.end()
+    }
+  }
+
   const stream = new Transform({
     async transform(chunk, encoding, callback) {
       if (encoding !== 'buffer' && encoding !== 'string') {
         callback(null, chunk)
         return
       }
+      this.push(chunk, encoding)
 
       let parsedChunk = null
-      try {
-        const chunkStr = chunk.toString()
-        if (chunkStr.trim() !== '') {
-          parsedChunk = JSON.parse(chunkStr)
+      for (const chunkStr of chunk.toString().split(splitRegex)) {
+        if (chunkStr.trim() === '') {
+          continue
         }
-      } catch (err) {
-        // Ignore JSON parse errors
-        // this can happen if the chunk is not a JSON object. We just pass it through and let the caller handle it.
-        debug('Failed to parse JSON chunk, ignoring', err, chunk.toString())
+
+        try {
+          parsedChunk = JSON.parse(chunkStr)
+        } catch (err) {
+          // Ignore JSON parse errors
+          // this can happen if the chunk is not a JSON object. We just pass it through and let the caller handle it.
+          debug('Failed to parse JSON chunk, ignoring', err, chunkStr)
+        }
+
+        if (
+          parsedChunk !== null &&
+          typeof parsedChunk === 'object' &&
+          'nextCursor' in parsedChunk &&
+          typeof parsedChunk.nextCursor === 'string' &&
+          !('_id' in parsedChunk)
+        ) {
+          debug('Got next cursor "%s", fetching next stream', parsedChunk.nextCursor)
+          streamsInflight++
+
+          const reqStream = await startStream(options, parsedChunk.nextCursor)
+          reqStream.on('end', () => decrementInflight(this))
+          reqStream.pipe(this, {end: false})
+        }
       }
 
-      if (
-        parsedChunk !== null &&
-        typeof parsedChunk === 'object' &&
-        'nextCursor' in parsedChunk &&
-        typeof parsedChunk.nextCursor === 'string' &&
-        !('_id' in parsedChunk)
-      ) {
-        debug('Got next cursor "%s", fetching next stream', parsedChunk.nextCursor)
-        streamsInflight++
-
-        const reqStream = await startStream(options, parsedChunk.nextCursor)
-        reqStream.on('end', () => {
-          streamsInflight--
-          if (streamsInflight === 0) {
-            stream.end()
-          }
-        })
-        reqStream.pipe(this, {end: false})
-
-        callback()
-        return
-      }
-
-      callback(null, chunk)
+      callback()
     },
   })
 
   streamsInflight++
   const reqStream = await startStream(options, '')
-  reqStream.on('end', () => {
-    streamsInflight--
-    if (streamsInflight === 0) {
-      stream.end()
-    }
-  })
-
+  reqStream.on('end', () => decrementInflight(stream))
   reqStream.pipe(stream, {end: false})
   return stream
 }

--- a/src/getDocumentCursorStream.js
+++ b/src/getDocumentCursorStream.js
@@ -77,5 +77,9 @@ function startStream(options, nextCursor) {
 
   debug('Starting stream with cursor "%s"', nextCursor)
 
-  return requestStream({url, headers, maxRetries: options.maxRetries})
+  return requestStream({url, headers, maxRetries: options.maxRetries}).then((res) => {
+    debug('Got stream with HTTP %d', res.statusCode)
+
+    return res
+  })
 }

--- a/src/getDocumentCursorStream.js
+++ b/src/getDocumentCursorStream.js
@@ -22,7 +22,7 @@ module.exports = async (options) => {
       } catch (err) {
         // Ignore JSON parse errors
         // this can happen if the chunk is not a JSON object. We just pass it through and let the caller handle it.
-        debug('Failed to parse JSON chunk', err)
+        debug('Failed to parse JSON chunk, ignoring', err, chunk.toString())
       }
 
       if (
@@ -32,7 +32,7 @@ module.exports = async (options) => {
         typeof parsedChunk.nextCursor === 'string' &&
         !('_id' in parsedChunk)
       ) {
-        debug('Got next cursor, fetching next stream', parsedChunk.nextCursor)
+        debug('Got next cursor "%s", fetching next stream', parsedChunk.nextCursor)
         streamsInflight++
 
         const reqStream = await startStream(options, parsedChunk.nextCursor)

--- a/src/getDocumentCursorStream.js
+++ b/src/getDocumentCursorStream.js
@@ -15,11 +15,14 @@ module.exports = async (options) => {
 
       let parsedChunk = null
       try {
-        parsedChunk = JSON.parse(chunk.toString())
+        const chunkStr = chunk.toString()
+        if (chunkStr.trim() !== '') {
+          parsedChunk = JSON.parse(chunkStr)
+        }
       } catch (err) {
         // Ignore JSON parse errors
         // this can happen if the chunk is not a JSON object. We just pass it through and let the caller handle it.
-        debug('Failed to parse JSON chunk', err, chunk.toString())
+        debug('Failed to parse JSON chunk', err)
       }
 
       if (

--- a/test/export.test.js
+++ b/test/export.test.js
@@ -534,7 +534,7 @@ describe('export', () => {
       {
         _id: 'third-but-not-the-last',
         _type: 'article',
-        title: 'Hello again, world!',
+        title: 'Hello again, \r\nworld!',
       },
       {
         _id: 'fourth-and-last',
@@ -550,6 +550,7 @@ describe('export', () => {
           res.write(JSON.stringify(documents[0]))
           res.write('\n')
           res.write(JSON.stringify({nextCursor: 'cursor-1'}))
+          res.write('\n')
           res.end()
           return
         }
@@ -558,21 +559,20 @@ describe('export', () => {
           res.write(JSON.stringify(documents[1]))
           res.write('\n')
           res.write(JSON.stringify({nextCursor: 'cursor-2'}))
+          res.write('\n')
           res.end()
           return
         }
 
         case 'cursor-2': {
-          res.write(JSON.stringify(documents[2]))
+          res.write(`${JSON.stringify(documents[2])}\n${JSON.stringify({nextCursor: 'cursor-3'})}`)
           res.write('\n')
-          res.write(JSON.stringify({nextCursor: 'cursor-3'}))
           res.end()
           return
         }
 
         case 'cursor-3': {
           res.write(JSON.stringify(documents[3]))
-          res.write('\n')
           res.end()
           return
         }


### PR DESCRIPTION
A chunk can contain multiple json documents, so we need to split it by newline before parsing it as json