### PR TITLE
Ignore 404 errors when downloading assets

### DIFF
--- a/src/AssetHandler.js
+++ b/src/AssetHandler.js
@@ -112,6 +112,12 @@ class AssetHandler {
         try {
           return await this.downloadAsset(assetDoc, dstPath)
         } catch (err) {
+          // Ignore missing assets
+          if (err.statusCode === 404) {
+            console.warn(`⚠ Asset not found (ignoring): %s`, assetDoc._id)
+            return false
+          }
+
           debug(
             `Error downloading asset %s (destination: %s), attempt %d`,
             assetDoc._id,
@@ -179,6 +185,9 @@ class AssetHandler {
   // eslint-disable-next-line max-statements
   async downloadAsset(assetDoc, dstPath) {
     const {url} = assetDoc
+
+    debug('Downloading asset %s', url)
+
     const options = this.getAssetRequestOptions(assetDoc)
 
     let stream

--- a/src/AssetHandler.js
+++ b/src/AssetHandler.js
@@ -112,10 +112,18 @@ class AssetHandler {
         try {
           return await this.downloadAsset(assetDoc, dstPath)
         } catch (err) {
-          // Ignore missing assets
-          if (err.statusCode === 404) {
-            console.warn(`⚠ Asset not found (ignoring): %s`, assetDoc._id)
-            return false
+          // Ignore inaccessible assets
+          switch (err.statusCode) {
+            case 401:
+            case 403:
+            case 404:
+              console.warn(
+                `⚠ Asset failed with HTTP %d (ignoring): %s`,
+                err.statusCode,
+                assetDoc._id,
+              )
+              return true
+            default:
           }
 
           debug(

--- a/src/export.js
+++ b/src/export.js
@@ -33,6 +33,12 @@ async function exportDataset(opts) {
         : zlib.constants.Z_NO_COMPRESSION,
     },
   })
+  archive.on('warning', (err) => {
+    debug('Archive warning: %s', err.message)
+  })
+  archive.on('entry', (entry) => {
+    debug('Adding archive entry: %s', entry.name)
+  })
 
   const slugDate = new Date()
     .toISOString()
@@ -225,10 +231,6 @@ async function exportDataset(opts) {
     debug('Finalizing archive, flushing streams')
     onProgress({step: 'Adding assets to archive...'})
     await archive.finalize()
-  })
-
-  archive.on('warning', (err) => {
-    debug('Archive warning: %s', err.message)
   })
 
   miss.pipe(archive, outputStream, onComplete)


### PR DESCRIPTION
This currently causes the export to fail. I have not looked into _why_ assets would be gone in this case, but that seems like a separate issue that is probably caused by asset documents getting out of async with the files, rather than stuff genuinely going missing. Either way, it should not prevent an export from completing.

Note that we don't have a great way to warn the user, as far as I can see. The importer has a way to collect warnings, but threading a similar mechanism through the exporter would be a bit of a chore, so I didn't do that yet.