### PR TITLE
feat: add Media Library export functionality

### DIFF
--- a/src/export.js
+++ b/src/export.js
@@ -160,6 +160,12 @@ async function exportDataset(opts) {
     assetStreamHandler,
     filterDocumentTypes(options.types),
     options.drafts ? miss.through.obj() : filterDrafts(),
+    miss.through.obj((doc, _enc, callback) => {
+      if (options.filterDocument(doc)) {
+        return callback(null, doc)
+      }
+      return callback()
+    }),
     miss.through.obj(reportDocumentCount),
     stringifyStream(),
   )

--- a/src/export.js
+++ b/src/export.js
@@ -166,6 +166,9 @@ async function exportDataset(opts) {
       }
       return callback()
     }),
+    miss.through.obj((doc, _enc, callback) => {
+      callback(null, options.transformDocument(doc))
+    }),
     miss.through.obj(reportDocumentCount),
     stringifyStream(),
   )

--- a/src/export.js
+++ b/src/export.js
@@ -47,7 +47,7 @@ async function exportDataset(opts) {
     .replace(/[^a-z0-9]/gi, '-')
     .toLowerCase()
 
-  const prefix = `${opts.dataset}-export-${slugDate}`
+  const prefix = `${opts.dataset ?? opts.mediaLibraryId}-export-${slugDate}`
   const tmpDir = path.join(os.tmpdir(), prefix)
   fs.mkdirSync(tmpDir, {recursive: true})
   const dataPath = path.join(tmpDir, 'data.ndjson')

--- a/src/export.js
+++ b/src/export.js
@@ -220,7 +220,11 @@ async function exportDataset(opts) {
 
       const assetsStream = fs.createWriteStream(assetsPath)
       await pipeAsync(new JsonStreamStringify(assetMap), assetsStream)
-      archive.file(assetsPath, {name: 'assets.json', prefix})
+
+      if (options.assetsMap) {
+        archive.file(assetsPath, {name: 'assets.json', prefix})
+      }
+
       clearInterval(progressInterval)
     } catch (assetErr) {
       clearInterval(progressInterval)

--- a/src/getDocumentCursorStream.js
+++ b/src/getDocumentCursorStream.js
@@ -66,9 +66,13 @@ module.exports = async (options) => {
 }
 
 function startStream(options, nextCursor) {
-  const url = options.client.getUrl(
-    `/data/export/${options.dataset}?nextCursor=${encodeURIComponent(nextCursor)}`,
+  const baseUrl = options.client.getUrl(
+    options.dataset
+      ? `/data/export/${options.dataset}`
+      : `/media-libraries/${options.mediaLibraryId}/export`,
   )
+
+  const url = `${baseUrl}?nextCursor=${encodeURIComponent(nextCursor)}`
   const token = options.client.config().token
   const headers = {
     'User-Agent': `${pkg.name}@${pkg.version}`,

--- a/src/getDocumentsStream.js
+++ b/src/getDocumentsStream.js
@@ -4,7 +4,12 @@ const requestStream = require('./requestStream')
 module.exports = (options) => {
   // Sanity client doesn't handle streams natively since we want to support node/browser
   // with same API. We're just using it here to get hold of URLs and tokens.
-  const url = options.client.getUrl(`/data/export/${options.dataset}`)
+  const url = options.client.getUrl(
+    options.dataset
+      ? `/data/export/${options.dataset}`
+      : `/media-libraries/${options.mediaLibraryId}/export`,
+  )
+
   const token = options.client.config().token
   const headers = {
     'User-Agent': `${pkg.name}@${pkg.version}`,

--- a/src/validateOptions.js
+++ b/src/validateOptions.js
@@ -20,6 +20,7 @@ const exportDefaults = {
   maxRetries: DOCUMENT_STREAM_MAX_RETRIES,
   maxAssetRetries: ASSET_DOWNLOAD_MAX_RETRIES,
   readTimeout: REQUEST_READ_TIMEOUT,
+  filterDocument: () => true,
 }
 
 function validateOptions(opts) {
@@ -76,6 +77,13 @@ function validateOptions(opts) {
 
   if (options.assetConcurrency && (options.assetConcurrency < 1 || options.assetConcurrency > 24)) {
     throw new Error('`assetConcurrency` must be between 1 and 24')
+  }
+
+  if (
+    typeof options.filterDocument !== 'undefined' &&
+    typeof options.filterDocument !== 'function'
+  ) {
+    throw new Error('`filterDocument` must be a function')
   }
 
   if (typeof assetsMap !== 'undefined' && typeof assetsMap !== 'boolean') {

--- a/src/validateOptions.js
+++ b/src/validateOptions.js
@@ -14,6 +14,7 @@ const exportDefaults = {
   compress: true,
   drafts: true,
   assets: true,
+  assetsMap: true,
   raw: false,
   mode: MODE_STREAM,
   maxRetries: DOCUMENT_STREAM_MAX_RETRIES,
@@ -75,6 +76,10 @@ function validateOptions(opts) {
 
   if (options.assetConcurrency && (options.assetConcurrency < 1 || options.assetConcurrency > 24)) {
     throw new Error('`assetConcurrency` must be between 1 and 24')
+  }
+
+  if (typeof assetsMap !== 'undefined' && typeof assetsMap !== 'boolean') {
+    throw new Error('`assetsMap` must be a boolean')
   }
 
   return options

--- a/src/validateOptions.js
+++ b/src/validateOptions.js
@@ -21,6 +21,7 @@ const exportDefaults = {
   maxAssetRetries: ASSET_DOWNLOAD_MAX_RETRIES,
   readTimeout: REQUEST_READ_TIMEOUT,
   filterDocument: () => true,
+  transformDocument: (doc) => doc,
 }
 
 function validateOptions(opts) {
@@ -84,6 +85,13 @@ function validateOptions(opts) {
     typeof options.filterDocument !== 'function'
   ) {
     throw new Error('`filterDocument` must be a function')
+  }
+
+  if (
+    typeof options.transformDocument !== 'undefined' &&
+    typeof options.transformDocument !== 'function'
+  ) {
+    throw new Error('`transformDocument` must be a function')
   }
 
   if (typeof assetsMap !== 'undefined' && typeof assetsMap !== 'boolean') {

--- a/src/validateOptions.js
+++ b/src/validateOptions.js
@@ -27,8 +27,20 @@ const exportDefaults = {
 function validateOptions(opts) {
   const options = defaults({}, opts, exportDefaults)
 
-  if (typeof options.dataset !== 'string' || options.dataset.length < 1) {
-    throw new Error(`options.dataset must be a valid dataset name`)
+  const resources = [options.dataset, options.mediaLibraryId].filter(
+    (resource) => typeof resource === 'string' && resource.length !== 0,
+  )
+
+  if (resources.length === 0) {
+    throw new Error(
+      'either `options.dataset` or `options.mediaLibraryId` must be specified, got neither',
+    )
+  }
+
+  if (resources.length === 2) {
+    throw new Error(
+      'either `options.dataset` or `options.mediaLibraryId` must be specified, got both',
+    )
   }
 
   if (


### PR DESCRIPTION
This branch adds support for exporting Media Library archives. Media Library archives differ from standard dataset exports in a few ways:

- The `data.ndjson` file:
  - Includes only `sanity.asset` document types.
  - Includes only the asset filename and aspect data.
  - Always excludes drafts.
  - Omits asset documents that have no aspect data.
- The assets map (`assets.json`) is omitted (the presence of assets in the archive is instead considered the source of truth).
- Data is retrieved from `/media-libraries/${options.mediaLibraryId}/export` instead of `/data/export/${options.dataset}`.

The following changes have been made to support this functionality:

### Assets map is now optional

The assets map file `assets.json` is redundant for Media Library archives. The `assetsMap` boolean option has been added to allow consumers to skip creation of the assets map. It defaults to `true` to avoid breaking existing usage.

### Document filtering has been added

The `filterDocument` option allows consumers to specify a callback that is given a document as a parameter and returns a boolean. This boolean controls whether a document is appended to `data.ndjson`. This is optional to avoid breaking existing usage.

### Document transformation has been added

The `transformDocument` option allows consumers to specify a callback that is given a document as a parameter and returns a new value. This controls the data appended to `data.ndjson`. This is optional to avoid breaking existing usage.

### Support for the Media Library export HTTP API has been added

Consumers may now specify the `mediaLibraryId` option _instead_ of the `dataset` option. When this occurs, the exported data will be fetched from the Media Library export HTTP API instead of the usual dataset export HTTP API.