### PR TITLE
Support exporting documents with specific types

### DIFF
--- a/src/filterDocumentTypes.js
+++ b/src/filterDocumentTypes.js
@@ -1,7 +1,7 @@
 const miss = require('mississippi')
 
 module.exports = (allowedTypes) =>
-  allowedTypes
+  allowedTypes && allowedTypes.length > 0
     ? miss.through.obj((doc, enc, callback) => {
         const type = doc && doc._type
         if (allowedTypes.includes(type)) {

--- a/src/getDocumentCursorStream.js
+++ b/src/getDocumentCursorStream.js
@@ -72,7 +72,13 @@ function startStream(options, nextCursor) {
       : `/media-libraries/${options.mediaLibraryId}/export`,
   )
 
-  const url = `${baseUrl}?nextCursor=${encodeURIComponent(nextCursor)}`
+  const queryParams = [`nextCursor=${encodeURIComponent(nextCursor)}`]
+
+  // Type filtering is only supported for datasets.
+  if (options.types && options.types.length > 0 && options.dataset) {
+    queryParams.push(`types=${options.types.join(',')}`)
+  }
+  const url = `${baseUrl}?${queryParams.join('&')}`
   const token = options.client.config().token
   const headers = {
     'User-Agent': `${pkg.name}@${pkg.version}`,

--- a/src/getDocumentsStream.js
+++ b/src/getDocumentsStream.js
@@ -4,11 +4,19 @@ const requestStream = require('./requestStream')
 module.exports = (options) => {
   // Sanity client doesn't handle streams natively since we want to support node/browser
   // with same API. We're just using it here to get hold of URLs and tokens.
-  const url = options.client.getUrl(
+  const baseUrl = options.client.getUrl(
     options.dataset
       ? `/data/export/${options.dataset}`
       : `/media-libraries/${options.mediaLibraryId}/export`,
   )
+  
+  // Type filtering is only supported for datasets.
+  const queryParams = []
+  if (options.types && options.types.length > 0 && options.dataset) {
+    queryParams.push(`types=${options.types.join(',')}`)
+  }
+  
+  const url = queryParams.length > 0? `${baseUrl}?${queryParams.join('&')}`: baseUrl
 
   const token = options.client.config().token
   const headers = {

--- a/src/validateOptions.js
+++ b/src/validateOptions.js
@@ -43,6 +43,10 @@ function validateOptions(opts) {
     )
   }
 
+  if (options.types && !options.dataset) {
+    throw new Error('`options.types` is only supported when exporting from a dataset')
+  }
+
   if (
     typeof options.mode !== 'string' ||
     (options.mode !== MODE_STREAM && options.mode !== MODE_CURSOR)


### PR DESCRIPTION
`types` is a documented field in CLI options. We have not been respecting it. This PR fixes that to allow type based exports for dataset documents.