### PR TITLE
Allow types filter on all the resource types

### DIFF
--- a/src/getDocumentCursorStream.js
+++ b/src/getDocumentCursorStream.js
@@ -75,8 +75,7 @@ function startStream(options, nextCursor) {
   const url = new URL(baseUrl)
   url.searchParams.set('nextCursor', nextCursor)
 
-  // Type filtering is only supported for datasets.
-  if (options.types && options.types.length > 0 && options.dataset) {
+  if (options.types && options.types.length > 0 ) {
     url.searchParams.set('types', options.types.join())
   }
   const token = options.client.config().token

--- a/src/getDocumentsStream.js
+++ b/src/getDocumentsStream.js
@@ -10,9 +10,8 @@ module.exports = (options) => {
       : `/media-libraries/${options.mediaLibraryId}/export`,
   )
   
-  // Type filtering is only supported for datasets.
   const url = new URL(baseUrl)
-  if (options.types && options.types.length > 0 && options.dataset) {
+  if (options.types && options.types.length > 0 ) {
     url.searchParams.set('types', options.types.join())
   }
 

--- a/test/getDocumentsStream.test.js
+++ b/test/getDocumentsStream.test.js
@@ -62,11 +62,11 @@ describe('getDocumentsStream', () => {
       })
     })
 
-    test('constructs URL for media library export without types parameter', () => {
+    test('constructs URL for media library export with types parameter', () => {
       const options = {
         mediaLibraryId: 'media-lib-123',
         client: getMockClient(),
-        types: ['article', 'author'], // Should be ignored for media library
+        types: ['article', 'author'],
         maxRetries: 2,
         readTimeout: 30000,
       }
@@ -74,7 +74,7 @@ describe('getDocumentsStream', () => {
       getDocumentsStreamTest(options)
 
       expect(mockRequestStream).toHaveBeenCalledWith({
-        url: 'https://projectid.api.sanity.io/v2021-06-07/media-libraries/media-lib-123/export',
+        url: 'https://projectid.api.sanity.io/v2021-06-07/media-libraries/media-lib-123/export?types=article%2Cauthor',
         headers: {
           'User-Agent': `${pkg.name}@${pkg.version}`,
           Authorization: 'Bearer skMockToken',


### PR DESCRIPTION
It seems I introduced a regression when working on https://github.com/sanity-io/export/pull/25. Type filtering is supported on all the resources.