### PR TITLE
fix: allow `types` option, regardless of whether `dataset` option is provided

### DIFF
--- a/src/validateOptions.js
+++ b/src/validateOptions.js
@@ -43,10 +43,6 @@ function validateOptions(opts) {
     )
   }
 
-  if (options.types && !options.dataset) {
-    throw new Error('`options.types` is only supported when exporting from a dataset')
-  }
-
   if (
     typeof options.mode !== 'string' ||
     (options.mode !== MODE_STREAM && options.mode !== MODE_CURSOR)


### PR DESCRIPTION
### Description

#29 made changes to allow export types to be defined for any resource—not just datasets—but an errant check was left in the options validator.

This causes the `sanity media export` command to fail, because it both targets a media library (rather than dataset) *and* provides a list of types to export.

### What to review

The options validator.