### PR TITLE
feat(assets): add flag to relax strict asset verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ exportDataset({
   // Optional, default: `true`
   assetsMap: true,
 
+  // Whether to strictly enforce asset verification (hash and content-length checks against
+  // the `x-sanity-sha1` / `x-sanity-md5` response headers). Set to `false` to keep assets
+  // that fail verification (with a warning) instead of aborting the export.
+  // Caution: disable only when recovering from known-bad source data (e.g. assets where the
+  // originally-uploaded bytes are no longer available server-side).
+  // Optional, default: `true`
+  strictAssetVerification: true,
+
   // A custom filter function for controlling which documents are exported.
   // Optional, default: `() => true`
   filterDocument: (document) => (document.title ?? '').includes('capybara'),

--- a/src/AssetHandler.ts
+++ b/src/AssetHandler.ts
@@ -39,6 +39,7 @@ interface AssetHandlerOptions {
   maxRetries?: number
   retryDelayMs?: number
   queue?: PQueue
+  strictAssetVerification?: boolean
 }
 
 interface AssetRequestOptions {
@@ -74,6 +75,7 @@ export class AssetHandler {
   maxRetries: number
   retryDelayMs: number | undefined
   queue: PQueue
+  strictAssetVerification: boolean
   rejectedError: Error | null
   reject: (err: Error) => void
 
@@ -93,6 +95,7 @@ export class AssetHandler {
     this.maxRetries = options.maxRetries ?? ASSET_DOWNLOAD_MAX_RETRIES
     this.retryDelayMs = options.retryDelayMs
     this.queue = options.queue ?? new PQueue({concurrency})
+    this.strictAssetVerification = options.strictAssetVerification ?? true
 
     this.rejectedError = null
     this.reject = (err: Error): void => {
@@ -365,9 +368,14 @@ export class AssetHandler {
 
       const detailsString = `Details:\n - ${details.filter(Boolean).join('\n - ')}`
 
-      await rm(tmpPath, {recursive: true, force: true})
-
-      throw new Error(`Failed to download asset at ${assetDoc.url}. ${detailsString}`)
+      if (this.strictAssetVerification) {
+        await rm(tmpPath, { recursive: true, force: true })
+        throw new Error(`Failed to download asset at ${assetDoc.url}. ${detailsString}`)
+      } else {
+        console.warn(
+          `⚠ ${assetDoc._id} failed asset verification (ignoring): ${detailsString}`,
+        )
+      }
     }
 
     const isImage = assetDoc._type === 'sanity.imageAsset'

--- a/src/export.ts
+++ b/src/export.ts
@@ -109,6 +109,7 @@ export async function exportDataset(opts: ExportOptions): Promise<ExportResult> 
     ...(options.assetConcurrency !== undefined && {concurrency: options.assetConcurrency}),
     ...(options.retryDelayMs !== undefined && {retryDelayMs: options.retryDelayMs}),
     maxRetries: options.maxAssetRetries,
+    strictAssetVerification: options.strictAssetVerification,
   })
 
   debug('Downloading assets (temporarily) to %s', tmpDir)

--- a/src/options.ts
+++ b/src/options.ts
@@ -7,7 +7,7 @@ import {
 } from './constants.js'
 import type {ExportOptions, ExportSource, NormalizedExportOptions, SanityDocument} from './types.js'
 
-const booleanFlags = ['assets', 'raw', 'compress', 'drafts'] as const
+const booleanFlags = ['assets', 'raw', 'compress', 'drafts', 'strictAssetVerification'] as const
 const numberFlags = ['maxAssetRetries', 'maxRetries', 'assetConcurrency', 'readTimeout'] as const
 
 const exportDefaults = {
@@ -15,6 +15,7 @@ const exportDefaults = {
   drafts: true,
   assets: true,
   assetsMap: true,
+  strictAssetVerification: true,
   raw: false,
   mode: MODE_STREAM,
   maxRetries: DOCUMENT_STREAM_MAX_RETRIES,

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,6 +146,15 @@ export type ExportOptions = {
   assetsMap?: boolean
 
   /**
+   * Whether to strictly enforce asset verification (hash and content-length checks).
+   * When `false`, assets which fail verification are kept (with a warning) instead of
+   * aborting the export.
+   *
+   * Default: `true`
+   */
+  strictAssetVerification?: boolean
+
+  /**
    * Optional filter function to determine whether or not a document should be included
    * in the export. Note that this is run after any built-in document filtering such as
    * draft exclusion, document type filtering, etc.
@@ -224,6 +233,7 @@ export type NormalizedExportOptions = ExportOptions & {
   mode: ExportMode
   compress: boolean
   assetsMap: boolean
+  strictAssetVerification: boolean
   filterDocument: (doc: SanityDocument) => boolean
   transformDocument: (doc: SanityDocument) => Partial<SanityDocument>
 }

--- a/test/AssetHandler-download.test.ts
+++ b/test/AssetHandler-download.test.ts
@@ -253,6 +253,162 @@ describe('AssetHandler download paths', () => {
     expect(assetMap[key]).toMatchObject({originalFilename: 'mead.png'})
   })
 
+  test('rejects when hash headers mismatch and strictAssetVerification is default (true)', async () => {
+    const port = 43218
+    server = await getServer(port, (_req, res) => {
+      res.writeHead(200, 'OK', {
+        'Content-Type': 'image/png',
+        'x-sanity-sha1': 'deadbeef'.repeat(5),
+        'x-sanity-md5': 'cafebabe'.repeat(4),
+      })
+      createReadStream(joinPath(import.meta.dirname, 'fixtures', 'mead.png')).pipe(res)
+    })
+
+    const tmpDir = joinPath(tmpBase, `verify-default-${Date.now()}`)
+    const handler = new AssetHandler({
+      client: getMockClient(port),
+      tmpDir,
+      maxRetries: 1,
+      retryDelayMs: 0,
+    })
+
+    const assetDoc: AssetDocument = {
+      _id: 'image-eca53d85ec83704801ead6c8be368fd377f8aaef-512x512-png',
+      _type: 'sanity.imageAsset',
+      url: `http://localhost:${port}/images/mead.png`,
+    }
+
+    handler.queueAssetDownload(
+      assetDoc,
+      'images/eca53d85ec83704801ead6c8be368fd377f8aaef-512x512.png',
+    )
+    await expect(handler.finish()).rejects.toThrow('Failed to download asset')
+  })
+
+  test('warns and continues when hash headers mismatch and strictAssetVerification is false', async () => {
+    const port = 43218
+    server = await getServer(port, (_req, res) => {
+      res.writeHead(200, 'OK', {
+        'Content-Type': 'image/png',
+        'x-sanity-sha1': 'deadbeef'.repeat(5),
+        'x-sanity-md5': 'cafebabe'.repeat(4),
+      })
+      createReadStream(joinPath(import.meta.dirname, 'fixtures', 'mead.png')).pipe(res)
+    })
+
+    const tmpDir = joinPath(tmpBase, `verify-off-${Date.now()}`)
+    const handler = new AssetHandler({
+      client: getMockClient(port),
+      tmpDir,
+      maxRetries: 1,
+      retryDelayMs: 0,
+      strictAssetVerification: false,
+    })
+
+    const warn = vitest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const assetDoc: AssetDocument = {
+      _id: 'image-eca53d85ec83704801ead6c8be368fd377f8aaef-512x512-png',
+      _type: 'sanity.imageAsset',
+      url: `http://localhost:${port}/images/mead.png`,
+      originalFilename: 'mead.png',
+    }
+
+    handler.queueAssetDownload(
+      assetDoc,
+      'images/eca53d85ec83704801ead6c8be368fd377f8aaef-512x512.png',
+    )
+    await handler.finish()
+
+    expect(handler.filesWritten).toBe(1)
+    const images = await readdir(joinPath(tmpDir, 'images'))
+    expect(images).toContain('eca53d85ec83704801ead6c8be368fd377f8aaef-512x512.png')
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(`${assetDoc._id} failed asset verification`),
+    )
+
+    warn.mockRestore()
+  })
+
+  test('strictAssetVerification:false keys assetMap entry by locally-computed sha1 (not asset doc _id)', async () => {
+    // We expect the assetMap to be keyed by `${type}-${localSha1}`. This ensures `@sanity/import` finds
+    // the correct metadata for the asset document when there is a mismatch between hashes (e.g. server-sanitized SVGs).
+    const port = 43218
+    const wrongSha1 = 'deadbeef'.repeat(5)
+    server = await getServer(port, (_req, res) => {
+      res.writeHead(200, 'OK', {
+        'Content-Type': 'image/png',
+        'x-sanity-sha1': wrongSha1,
+      })
+      createReadStream(joinPath(import.meta.dirname, 'fixtures', 'mead.png')).pipe(res)
+    })
+
+    const tmpDir = joinPath(tmpBase, `verify-off-keying-${Date.now()}`)
+    const handler = new AssetHandler({
+      client: getMockClient(port),
+      tmpDir,
+      maxRetries: 1,
+      retryDelayMs: 0,
+      strictAssetVerification: false,
+    })
+
+    const warn = vitest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const assetDoc: AssetDocument = {
+      _id: `image-${wrongSha1}-512x512-png`,
+      _type: 'sanity.imageAsset',
+      url: `http://localhost:${port}/images/mismatch.png`,
+      originalFilename: 'mead.png',
+    }
+
+    handler.queueAssetDownload(assetDoc, `images/${wrongSha1}-512x512.png`)
+    const assetMap = await handler.finish()
+
+    // Local sha1 of the served bytes (mead.png) is the canonical one
+    const localSha1 = 'eca53d85ec83704801ead6c8be368fd377f8aaef'
+    expect(Object.keys(assetMap)).toEqual([`image-${localSha1}`])
+    expect(Object.keys(assetMap)).not.toContain(`image-${wrongSha1}`)
+    expect(assetMap[`image-${localSha1}`]).toMatchObject({originalFilename: 'mead.png'})
+
+    warn.mockRestore()
+  })
+
+  test('strictAssetVerification:false is a no-op when server omits hash headers', async () => {
+    const port = 43218
+    server = await getServer(port, (_req, res) => {
+      res.writeHead(200, 'OK', {'Content-Type': 'image/png'})
+      createReadStream(joinPath(import.meta.dirname, 'fixtures', 'mead.png')).pipe(res)
+    })
+
+    const tmpDir = joinPath(tmpBase, `verify-no-headers-${Date.now()}`)
+    const handler = new AssetHandler({
+      client: getMockClient(port),
+      tmpDir,
+      maxRetries: 1,
+      retryDelayMs: 0,
+      strictAssetVerification: false,
+    })
+
+    const warn = vitest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const assetDoc: AssetDocument = {
+      _id: 'image-eca53d85ec83704801ead6c8be368fd377f8aaef-512x512-png',
+      _type: 'sanity.imageAsset',
+      url: `http://localhost:${port}/images/mead.png`,
+    }
+
+    handler.queueAssetDownload(
+      assetDoc,
+      'images/eca53d85ec83704801ead6c8be368fd377f8aaef-512x512.png',
+    )
+    await handler.finish()
+
+    expect(handler.filesWritten).toBe(1)
+    expect(warn).not.toHaveBeenCalled()
+
+    warn.mockRestore()
+  })
+
   test('adds Authorization header for image assets on cdn.sanity.io', () => {
     const tmpDir = joinPath(tmpBase, `auth-${Date.now()}`)
     const handler = new AssetHandler({

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -115,7 +115,7 @@ describe('validateOptions', () => {
   })
 
   test('throws if boolean flags are not boolean', () => {
-    for (const flag of ['assets', 'raw', 'compress', 'drafts'] as const) {
+    for (const flag of ['assets', 'raw', 'compress', 'drafts', 'strictAssetVerification'] as const) {
       expect(() =>
         // @ts-expect-error Testing invalid boolean
         validateOptions({...validOptions(), [flag]: 'yes'}),
@@ -194,6 +194,7 @@ describe('validateOptions', () => {
     expect(result.raw).toBe(false)
     expect(result.mode).toBe('stream')
     expect(result.assetsMap).toBe(true)
+    expect(result.strictAssetVerification).toBe(true)
     expect(typeof result.filterDocument).toBe('function')
     expect(typeof result.transformDocument).toBe('function')
   })


### PR DESCRIPTION
Add a flag to skip strict asset verification. This is in response to an issue where sanitized SVGs are blocking dataset exports.
