### PR TITLE
chore: add workflow dispatch to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - alpha
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
Add `workflow_dispatch` to release workflow to enable manual triggering.
