### PR TITLE
fix: exclude uploadId from exported assets

### DIFF
--- a/src/AssetHandler.ts
+++ b/src/AssetHandler.ts
@@ -25,7 +25,16 @@ import type {
 } from './types.js'
 import {rm} from 'node:fs/promises'
 
-const EXCLUDE_PROPS = ['_id', '_type', 'assetId', 'extension', 'mimeType', 'path', 'url']
+const EXCLUDE_PROPS = [
+  '_id',
+  '_type',
+  'assetId',
+  'extension',
+  'mimeType',
+  'path',
+  'uploadId',
+  'url',
+]
 const ACTION_REMOVE = 'remove' as const
 const ACTION_REWRITE = 'rewrite' as const
 

--- a/test/AssetHandler-download.test.ts
+++ b/test/AssetHandler-download.test.ts
@@ -253,6 +253,45 @@ describe('AssetHandler download paths', () => {
     expect(assetMap[key]).toMatchObject({originalFilename: 'mead.png'})
   })
 
+  test('excludes uploadId from the exported asset metadata', async () => {
+    // `uploadId` is a per-upload token the asset service stamps on both the stored blob and the
+    // asset document, and it declines to delete the blob when the two disagree — that guard stops
+    // a late async delete from wiping a blob that has since been re-uploaded to the same
+    // content-addressed path.
+    const port = 43218
+    server = await getServer(port, (_req, res) => {
+      res.writeHead(200, 'OK', {'Content-Type': 'image/png'})
+      createReadStream(joinPath(import.meta.dirname, 'fixtures', 'mead.png')).pipe(res)
+    })
+
+    const tmpDir = joinPath(tmpBase, `upload-id-${Date.now()}`)
+    const handler = new AssetHandler({
+      client: getMockClient(port),
+      tmpDir,
+      maxRetries: 1,
+      retryDelayMs: 0,
+    })
+
+    const assetDoc: AssetDocument = {
+      _id: 'image-eca53d85ec83704801ead6c8be368fd377f8aaef-512x512-png',
+      _type: 'sanity.imageAsset',
+      url: `http://localhost:${port}/images/mead.png`,
+      originalFilename: 'mead.png',
+      uploadId: 'a3813c49e4a10c652e6c8db1a63432ce9946960e',
+    }
+
+    handler.queueAssetDownload(
+      assetDoc,
+      'images/eca53d85ec83704801ead6c8be368fd377f8aaef-512x512.png',
+    )
+    const assetMap = await handler.finish()
+
+    const entry = assetMap['image-eca53d85ec83704801ead6c8be368fd377f8aaef']
+    expect(entry).not.toHaveProperty('uploadId')
+    // Genuine user metadata is still exported
+    expect(entry).toMatchObject({originalFilename: 'mead.png'})
+  })
+
   test('rejects when hash headers mismatch and strictAssetVerification is default (true)', async () => {
     const port = 43218
     server = await getServer(port, (_req, res) => {


### PR DESCRIPTION
## Problem

`uploadId` is a per-upload token that the asset service stamps on **both** the stored blob's object metadata and the asset document. On delete, the document's value is sent as `?uploadId=` and the storage layer declines to remove the blob when the two disagree. That guard exists to stop a late async delete from wiping a blob that has since been re-uploaded to the same content-addressed path.

`assets.json` is written as `omit(assetDoc, EXCLUDE_PROPS)`, and `uploadId` was not in `EXCLUDE_PROPS` — so the source dataset's token gets recorded into the export. A later import re-uploads the binary (which mints a **fresh** token on the new blob) and then replays the exported value onto the new asset document. The two diverge permanently and the blob can never be deleted again: the delete API returns 200 and the asset document goes away, but the binary is orphaned in storage (CLDX-5818).

## Change

Add `uploadId` to `EXCLUDE_PROPS` so it is never recorded in `assets.json`.

## Test

New case `excludes uploadId from the exported asset metadata` in the existing `AssetHandler download paths` block of `test/AssetHandler-download.test.ts`, reusing that file's local HTTP server harness and `mead.png` fixture.

Verified RED before the change:

```
AssertionError: expected { originalFilename: 'mead.png', …(1) } to not have property "uploadId"
```

GREEN after. Full suite: 125 passing across 11 files.

## Scope

This stops **new** exports from recording the field. The durable fix is the import-side strip, which also neutralises the `uploadId` already baked into export tarballs in the wild — see `sanity-io/import` branch `cldx-5818-import-uploadid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)